### PR TITLE
rework laser: 19ch DMX, patterns, raycast clip, configurable passthrough

### DIFF
--- a/common/src/main/java/com/github/dumann089/theatricalextralights/blockentities/LaserBlockEntity.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/blockentities/LaserBlockEntity.java
@@ -230,6 +230,7 @@ public class LaserBlockEntity extends BaseDMXConsumerLightBlockEntity {
         public final float[] pitches;
         public final float[] lengths;
         public final int[] colors;
+        public final boolean[] hits;
         public int ageFrames;
 
         public TrailFrame(int n) {
@@ -237,6 +238,7 @@ public class LaserBlockEntity extends BaseDMXConsumerLightBlockEntity {
             this.pitches = new float[n];
             this.lengths = new float[n];
             this.colors = new int[n];
+            this.hits = new boolean[n];
             this.ageFrames = 0;
         }
     }

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/client/blockentities/LaserRenderer.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/client/blockentities/LaserRenderer.java
@@ -18,8 +18,8 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.Direction;
-import dev.imabad.theatrical.blockentities.light.BaseLightBlockEntity;
-import dev.imabad.theatrical.blocks.light.BaseLightBlock;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
@@ -29,7 +29,6 @@ import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
-import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 
@@ -169,7 +168,7 @@ public class LaserRenderer extends FixtureRenderer<LaserBlockEntity> {
                 }
 
                 int focus = blockEntity.getFocus();
-                float beamWidth = 0.02f + (focus / 255f) * 0.06f;
+                float beamWidth = 0.04f + (focus / 255f) * 0.10f;
                 float baseLength = TheatricalExtraLightsConfig.getLaserBeamLength();
 
                 Vec3 baseOrigin = new Vec3(0.5F, 0.5F, 0.0F);
@@ -177,112 +176,32 @@ public class LaserRenderer extends FixtureRenderer<LaserBlockEntity> {
                     baseOrigin = new Vec3(baseOrigin.x, 1.0 - baseOrigin.y, baseOrigin.z);
                 }
 
-                // ----- Single raycast on the laser's main aim direction. Every beam in
-                // the pattern uses this same effective length so the polyline shape
-                // stays uniform (drawn on whatever surface the laser is pointing at,
-                // or projected to max length in open space). Per-beam clipping caused
-                // ugly artifacts in complex scenes where beams hit nearby truss/decor.
-                float baseEffLen = raycastBeamLength(blockEntity, 0f, 0f, baseLength);
+                // ----- Beam length: DMX-driven max length, but each beam clips
+                // at the first solid wall it hits so beams don't pass through
+                // surfaces. Pattern size (angular spread) is independent and
+                // set in LaserPattern via the Size DMX channel.
                 float[] effLengths = new float[beams.size()];
+                boolean[] beamHits = new boolean[beams.size()];
                 for (int i = 0; i < beams.size(); i++) {
                     LaserBeam beam = beams.get(i);
-                    effLengths[i] = baseEffLen * (beam.length / 32f);
+                    float maxLen = baseLength * (beam.length / 32f);
+                    boolean[] hit = new boolean[1];
+                    effLengths[i] = raycastBeamLengthDebug(blockEntity, beam.yawDeg, beam.pitchDeg, maxLen, hit, null);
+                    beamHits[i] = true; // always render — pattern keeps its shape even when no wall
                 }
+                boolean anyHit = true;
 
-                int persistenceRaw = blockEntity.getPersistenceRaw();
-                Deque<LaserBlockEntity.TrailFrame> trail = blockEntity.getTrailBuffer();
+                blockEntity.getTrailBuffer().clear();
 
-                // ----- Scanning beam mode for polyline patterns -----
-                // Real lasers project a SINGLE beam that scans the pattern at high speed.
-                // Persistence (eye/trail) makes the full shape visible. We replicate this:
-                // each beam in the pattern is rendered with a fade-out alpha based on its
-                // distance from the current "scan position" (which moves over time).
-                // - Persistence DMX low  → narrow fade window → only 1-2 bright beams visible
-                //   = clearly looks like one scanning beam
-                // - Persistence DMX high → wide fade window → most/all of the pattern visible
-                //   = the full pattern's shape is drawn
-                // Scan rate is half the render frame rate (~30 sweeps/sec at 60 fps).
-                // Faster than this aliases badly; slower makes motion look laggy.
-                // Real galvos run at 30-100k pps which equals hundreds of sweeps/sec,
-                // but at MC's 60 fps that's not perceivable — 30 Hz here matches the
-                // "feels like a fast continuous laser" sweet spot.
-                final float scanRate = 15.0f;
-                int patternN = beams.size();
-                float scanPos = (float) (((animTimeSec * scanRate) % 1.0) * patternN);
-                // Wide fade window by default so the pattern stays readable at high
-                // scan rate. Persistence still controls the trail length, but the
-                // floor (patternN * 0.6f) ensures the scan motion never makes the
-                // pattern unreadable.
-                float fadeWindow = Math.max(patternN * 0.6f,
-                        (persistenceRaw / 255f) * patternN + 1f);
-                boolean scanning = pattern.usesPolyline() && patternN >= 2;
-
-                LaserBlockEntity.TrailFrame snapshot = new LaserBlockEntity.TrailFrame(beams.size());
-                for (int i = 0; i < beams.size(); i++) {
-                    LaserBeam beam = beams.get(i);
-                    snapshot.yaws[i] = beam.yawDeg;
-                    snapshot.pitches[i] = beam.pitchDeg;
-                    snapshot.lengths[i] = effLengths[i];
-                    snapshot.colors[i] = beam.color;
-                }
-
-                if (scanning) {
-                    // Render each beam with a fading alpha relative to the scan position.
-                    float[] alphasByBeam = new float[patternN];
-                    for (int i = 0; i < patternN; i++) {
-                        // Distance "behind" the scan (pattern wraps around)
-                        float dist = scanPos - i;
-                        if (dist < 0) dist += patternN;
-                        if (dist < fadeWindow) {
-                            float t = dist / fadeWindow;
-                            alphasByBeam[i] = (1.0f - t) * intensity01;
-                        } else {
-                            alphasByBeam[i] = 0f;
-                        }
-                    }
-                    for (int i = 0; i < patternN; i++) {
-                        if (alphasByBeam[i] < 0.005f) continue;
-                        LaserBeam beam = beams.get(i);
+                // Render every beam at full intensity — no scan effect.
+                if (anyHit) {
+                    for (int idx = 0; idx < beams.size(); idx++) {
+                        if (!beamHits[idx]) continue;
+                        LaserBeam beam = beams.get(idx);
                         renderOneBeam(beamConsumer, poseStack, baseOrigin,
-                                beam.yawDeg, beam.pitchDeg, effLengths[i], beamWidth, beam.color, alphasByBeam[i]);
+                                beam.yawDeg, beam.pitchDeg, effLengths[idx], beamWidth,
+                                beam.color, intensity01);
                     }
-
-                    // Polyline ribbons between consecutive endpoints, with the same scan-fade alpha.
-                    float ribbonHalfWidth = beamWidth * 1.4f;
-                    Vec3 prevPt = computeEndpoint(baseOrigin, beams.get(0).yawDeg, beams.get(0).pitchDeg, effLengths[0]);
-                    for (int i = 1; i < patternN; i++) {
-                        LaserBeam beam = beams.get(i);
-                        Vec3 currPt = computeEndpoint(baseOrigin, beam.yawDeg, beam.pitchDeg, effLengths[i]);
-                        // Use the smaller of the two beams' fade alphas so segments behind the
-                        // scan front are dimmed consistently.
-                        float segAlpha = Math.min(alphasByBeam[i - 1], alphasByBeam[i]) * 0.75f;
-                        if (segAlpha > 0.005f) {
-                            renderRibbon(beamConsumer, poseStack, prevPt, currPt, ribbonHalfWidth, beam.color, segAlpha);
-                        }
-                        prevPt = currPt;
-                    }
-                    if (pattern.isClosed()) {
-                        Vec3 firstPt = computeEndpoint(baseOrigin, beams.get(0).yawDeg, beams.get(0).pitchDeg, effLengths[0]);
-                        float segAlpha = Math.min(alphasByBeam[patternN - 1], alphasByBeam[0]) * 0.75f;
-                        if (segAlpha > 0.005f) {
-                            renderRibbon(beamConsumer, poseStack, prevPt, firstPt, ribbonHalfWidth, beams.get(0).color, segAlpha);
-                        }
-                    }
-                } else {
-                    // Non-polyline patterns (BEAM_SIMPLE, SCATTER, BURST): render every beam
-                    // at full intensity. They're inherently radial/random so scanning doesn't apply.
-                    for (int i = 0; i < beams.size(); i++) {
-                        LaserBeam beam = beams.get(i);
-                        renderOneBeam(beamConsumer, poseStack, baseOrigin,
-                                beam.yawDeg, beam.pitchDeg, effLengths[i], beamWidth, beam.color, intensity01);
-                    }
-                }
-
-                // Trail buffer is no longer used (scanning + fade-window approach
-                // computes alpha analytically from animTimeSec and persistenceRaw).
-                // Keep it cleared so old code paths don't accumulate stale frames.
-                if (!trail.isEmpty()) {
-                    trail.clear();
                 }
 
                 poseStack.popPose();
@@ -318,30 +237,58 @@ public class LaserRenderer extends FixtureRenderer<LaserBlockEntity> {
      *  Real walls beyond this distance still block beams. */
     private static final float RAYCAST_SKIP_RADIUS = 2.5f;
 
-    private float raycastBeamLength(LaserBlockEntity be, float yawDeg, float pitchDeg, float maxLen) {
+    /**
+     * @param hitOut single-element array; set to {@code true} if the ray actually
+     *               hit a surface beyond the skip radius (real wall/floor) and
+     *               {@code false} if it goes into open space (no surface to
+     *               project the polyline onto). Caller can decide whether to
+     *               draw the trace.
+     */
+    private float raycastBeamLengthDebug(LaserBlockEntity be, float yawDeg, float pitchDeg,
+                                         float maxLen, boolean[] hitOut, String[] dbgOut) {
+        hitOut[0] = false;
+        if (dbgOut != null && dbgOut.length > 0) dbgOut[0] = null;
         if (be == null || be.getLevel() == null || maxLen <= 0.001f) return maxLen;
         Vec3 origin = be.getBlockPos().getCenter();
         Vec3 dir = getBeamWorldDir(be, yawDeg, pitchDeg);
         if (dir.lengthSqr() < 1e-8) return maxLen;
         Vec3 endWorld = origin.add(dir.scale(maxLen));
 
-        // Iteratively skip hits that fall within the mounting-structure radius
-        // around the laser. Once the ray finds a hit beyond this radius, that's
-        // a real wall and we stop there. Cap iterations so we never loop forever
-        // on weird geometry.
+        // Iteratively skip:
+        //   - hits within the mounting-structure radius (close truss/laser block)
+        //   - hits on Theatrical/TheatricalExtraLights blocks at any distance (the
+        //     whole rig can be made of these and shouldn't catch beams)
+        // Stop only when we find a non-mod block beyond the skip radius.
         Vec3 rayStart = origin;
-        int safety = 16;
+        int safety = 24;
         while (safety-- > 0) {
             BlockHitResult hit = be.getLevel().clip(new ClipContext(rayStart, endWorld,
                     ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, null));
             if (hit.getType() == HitResult.Type.MISS) {
                 return maxLen;
             }
+            BlockState hitState = be.getLevel().getBlockState(hit.getBlockPos());
+            ResourceLocation key = BuiltInRegistries.BLOCK.getKey(hitState.getBlock());
+            boolean isModBlock = key != null
+                    && (key.getNamespace().equals("theatrical")
+                        || key.getNamespace().equals("theatricalextralights"));
+            boolean isPassThrough = key != null
+                    && TheatricalExtraLightsConfig.isLaserPassThrough(key.toString());
             float dist = (float) hit.getLocation().distanceTo(origin);
-            if (dist >= RAYCAST_SKIP_RADIUS) {
+
+            if (!isModBlock && !isPassThrough && dist >= RAYCAST_SKIP_RADIUS) {
+                hitOut[0] = true;
+                if (dbgOut != null && dbgOut.length > 0) {
+                    Vec3 hl = hit.getLocation();
+                    dbgOut[0] = "hit=" + (key == null ? "?" : key.toString())
+                            + "@dist=" + String.format("%.1f", dist)
+                            + " worldXYZ=(" + String.format("%.0f", hl.x)
+                            + "," + String.format("%.0f", hl.y)
+                            + "," + String.format("%.0f", hl.z) + ")";
+                }
                 return Math.min(maxLen, dist);
             }
-            // Skip this hit, continue past it
+            // Skip this hit (mod block, or close truss/mounting), continue past it.
             rayStart = hit.getLocation().add(dir.scale(0.01));
             if (rayStart.distanceToSqr(endWorld) < 1e-4) {
                 return maxLen;
@@ -351,44 +298,70 @@ public class LaserRenderer extends FixtureRenderer<LaserBlockEntity> {
     }
 
     /**
-     * Compute a beam's world-space direction by combining the laser's effective
-     * pan/tilt (which already accounts for facing/hanging/upside-down) with per-beam
-     * yaw/pitch offsets, then converting to a unit vector via the same view-vector
-     * formula used by Theatrical's {@code rayTraceDir}.
+     * Compute the world-space direction of a beam by replicating EXACTLY the
+     * pose-stack rotation chain used by {@link #preparePoseStack} and
+     * {@link #renderOneBeam}, applied to the local +Z forward vector. This
+     * guarantees the raycast direction matches what's actually rendered
+     * regardless of facing, hanging direction, flipped state, pan, or tilt.
      */
     private static Vec3 getBeamWorldDir(LaserBlockEntity be, float beamYawDeg, float beamPitchDeg) {
-        BlockState bs = be.getBlockState();
-        net.minecraft.core.Direction hangDir = bs.getValue(BaseLightBlock.HANG_DIRECTION);
-        net.minecraft.core.Direction facing = bs.getValue(BaseLightBlock.FACING);
-        boolean isHangingNonVertically = BaseLightBlockEntity.isHangingNonVertically(
-                hangDir, bs.getValue(BaseLightBlock.HANGING));
+        BlockState state = be.getBlockState();
+        Direction facing = state.getValue(dev.imabad.theatrical.blocks.light.BaseLightBlock.FACING);
+        Direction hangDir = Direction.UP;
+        boolean isHanging = false;
+        try {
+            hangDir = state.getValue(dev.imabad.theatrical.blocks.HangableBlock.HANG_DIRECTION);
+            isHanging = state.getValue(dev.imabad.theatrical.blocks.HangableBlock.HANGING);
+        } catch (Exception ignored) {}
+        boolean isFlipped = be.isUpsideDown();
+        float pan = be.getPan();
+        float tilt = be.getTilt();
 
-        if (!isHangingNonVertically) {
-            float tilt = be.getTilt();
-            if (be.isUpsideDown() || be.getFixture().invertTilt()) {
-                tilt = -tilt;
-            }
-            float pan = (facing.toYRot() - be.getPan());
-            if (facing.getAxis() == net.minecraft.core.Direction.Axis.X) {
-                pan -= 180;
-            }
-            if (be.getFixture().invertPan()) {
-                pan *= -1;
-            }
-            if (be.isUpsideDown()) {
-                if (facing.getAxis() == net.minecraft.core.Direction.Axis.X) {
-                    pan = facing.getOpposite().toYRot() + be.getPan();
+        PoseStack temp = new PoseStack();
+
+        // ---- Mirror preparePoseStack rotations (translates omitted — they
+        // don't affect direction). The pose calls right-multiply, and vertex
+        // transforms apply in REVERSE-push order, but that's exactly what
+        // we want when feeding a pure +Z vertex in at the end. ----
+        if (isHanging && hangDir.getAxis() != Direction.Axis.Y) {
+            if (hangDir.getAxis() == Direction.Axis.Z) {
+                temp.mulPose(Axis.ZP.rotationDegrees(90));
+                if (hangDir == Direction.SOUTH) {
+                    temp.mulPose(Axis.XP.rotationDegrees(-90));
                 } else {
-                    pan = facing.toYRot() + be.getPan();
+                    temp.mulPose(Axis.XP.rotationDegrees(90));
+                }
+            } else {
+                if (hangDir == Direction.EAST) {
+                    temp.mulPose(Axis.ZN.rotationDegrees(-90));
+                } else {
+                    temp.mulPose(Axis.ZN.rotationDegrees(90));
                 }
             }
-            // Per-beam offsets: panPerBeam = panBase - beamYaw, tiltPerBeam = tiltBase + beamPitch
-            return BaseLightBlockEntity.calculateViewVector(tilt + beamPitchDeg, pan - beamYawDeg);
         }
-        // Non-vertical hanging is rare for lasers; fall back to base direction
-        // (per-beam offsets ignored — the pattern won't raycast individually but at
-        // least it stays consistent regardless of camera angle).
-        return BaseLightBlockEntity.rayTraceDir(be);
+        temp.mulPose(Axis.YP.rotationDegrees(facing.toYRot()));
+        if (isFlipped) {
+            temp.mulPose(Axis.ZP.rotationDegrees(180));
+        }
+        temp.mulPose(Axis.YP.rotationDegrees(pan));
+        if (isFlipped) {
+            temp.mulPose(Axis.XP.rotationDegrees(-180));
+        } else {
+            temp.mulPose(Axis.XP.rotationDegrees(180));
+        }
+        temp.mulPose(Axis.XP.rotationDegrees(tilt));
+
+        // ---- Beam-local rotations (renderOneBeam) ----
+        temp.mulPose(Axis.YP.rotationDegrees(beamYawDeg));
+        temp.mulPose(Axis.XP.rotationDegrees(beamPitchDeg));
+
+        // Apply the composed matrix to the model +Z vector.
+        Matrix4f m = temp.last().pose();
+        org.joml.Vector4f v = new org.joml.Vector4f(0f, 0f, 1f, 0f);
+        v.mul(m);
+        Vec3 dir = new Vec3(v.x, v.y, v.z);
+        if (dir.lengthSqr() < 1e-8) return Vec3.ZERO;
+        return dir.normalize();
     }
 
     /**
@@ -465,37 +438,59 @@ public class LaserRenderer extends FixtureRenderer<LaserBlockEntity> {
         int g = (color >> 8) & 0xFF;
         int b = color & 0xFF;
         int a = (int) (Math.max(0f, Math.min(1f, alpha)) * 255);
-        // Far end keeps 40% of the start alpha so the beam tip stays visible
-        // (instead of fading to nothing) — like a real laser hitting fog/surface.
-        int aFar = Math.max(0, (int) (a * 0.4f));
         Matrix4f m = stack.last().pose();
         Matrix3f normal = stack.last().normal();
 
-        float endMultiplier = beamSize;
+        // Beam splits into two segments: full opacity for the first 80% of
+        // the length, then a linear fade from 100% → 0% alpha over the last
+        // 20%. Thickness stays uniform so the cone keeps a clean shape.
+        float zMid = length * 0.8f;
+        float s = beamSize;
 
-        // R Face
-        addVertex(builder, m, normal, r, g, b, aFar, beamSize * endMultiplier, beamSize * endMultiplier, length);
-        addVertex(builder, m, normal, r, g, b, a, beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, a, beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, aFar, beamSize * endMultiplier, -beamSize * endMultiplier, length);
+        // Segment 1: [0 .. 0.8 length], uniform full alpha
+        // R face
+        addVertex(builder, m, normal, r, g, b, a,  s,  s, zMid);
+        addVertex(builder, m, normal, r, g, b, a,  s,  s, 0);
+        addVertex(builder, m, normal, r, g, b, a,  s, -s, 0);
+        addVertex(builder, m, normal, r, g, b, a,  s, -s, zMid);
+        // L face
+        addVertex(builder, m, normal, r, g, b, a, -s, -s, zMid);
+        addVertex(builder, m, normal, r, g, b, a, -s, -s, 0);
+        addVertex(builder, m, normal, r, g, b, a, -s,  s, 0);
+        addVertex(builder, m, normal, r, g, b, a, -s,  s, zMid);
+        // Top face
+        addVertex(builder, m, normal, r, g, b, a, -s,  s, zMid);
+        addVertex(builder, m, normal, r, g, b, a, -s,  s, 0);
+        addVertex(builder, m, normal, r, g, b, a,  s,  s, 0);
+        addVertex(builder, m, normal, r, g, b, a,  s,  s, zMid);
+        // Down face
+        addVertex(builder, m, normal, r, g, b, a,  s, -s, zMid);
+        addVertex(builder, m, normal, r, g, b, a,  s, -s, 0);
+        addVertex(builder, m, normal, r, g, b, a, -s, -s, 0);
+        addVertex(builder, m, normal, r, g, b, a, -s, -s, zMid);
 
-        // L Face
-        addVertex(builder, m, normal, r, g, b, aFar, -beamSize * endMultiplier, -beamSize * endMultiplier, length);
-        addVertex(builder, m, normal, r, g, b, a, -beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, a, -beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, aFar, -beamSize * endMultiplier, beamSize * endMultiplier, length);
-
-        // Top Face
-        addVertex(builder, m, normal, r, g, b, aFar, -beamSize * endMultiplier, beamSize * endMultiplier, length);
-        addVertex(builder, m, normal, r, g, b, a, -beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, a, beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, aFar, beamSize * endMultiplier, beamSize * endMultiplier, length);
-
-        // Down Face
-        addVertex(builder, m, normal, r, g, b, aFar, beamSize * endMultiplier, -beamSize * endMultiplier, length);
-        addVertex(builder, m, normal, r, g, b, a, beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, a, -beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, aFar, -beamSize * endMultiplier, -beamSize * endMultiplier, length);
+        // Segment 2: [0.8 length .. length], alpha fades to 0
+        int aEnd = 0;
+        // R face
+        addVertex(builder, m, normal, r, g, b, aEnd,  s,  s, length);
+        addVertex(builder, m, normal, r, g, b, a,    s,  s, zMid);
+        addVertex(builder, m, normal, r, g, b, a,    s, -s, zMid);
+        addVertex(builder, m, normal, r, g, b, aEnd,  s, -s, length);
+        // L face
+        addVertex(builder, m, normal, r, g, b, aEnd, -s, -s, length);
+        addVertex(builder, m, normal, r, g, b, a,   -s, -s, zMid);
+        addVertex(builder, m, normal, r, g, b, a,   -s,  s, zMid);
+        addVertex(builder, m, normal, r, g, b, aEnd, -s,  s, length);
+        // Top face
+        addVertex(builder, m, normal, r, g, b, aEnd, -s,  s, length);
+        addVertex(builder, m, normal, r, g, b, a,   -s,  s, zMid);
+        addVertex(builder, m, normal, r, g, b, a,    s,  s, zMid);
+        addVertex(builder, m, normal, r, g, b, aEnd,  s,  s, length);
+        // Down face
+        addVertex(builder, m, normal, r, g, b, aEnd,  s, -s, length);
+        addVertex(builder, m, normal, r, g, b, a,    s, -s, zMid);
+        addVertex(builder, m, normal, r, g, b, a,   -s, -s, zMid);
+        addVertex(builder, m, normal, r, g, b, aEnd, -s, -s, length);
     }
 
     @Override

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/config/TheatricalExtraLightsConfig.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/config/TheatricalExtraLightsConfig.java
@@ -7,6 +7,10 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class TheatricalExtraLightsConfig {
 
@@ -15,9 +19,24 @@ public class TheatricalExtraLightsConfig {
 
     /* ================= DEFAULT VALUES ================= */
 
-    private Float laserBeamLength = 60.0f;
+    private Float laserBeamLength = 400.0f;
     private Float rgbBarBeamLength = 9.0f;
     private Boolean renderLens = true;
+    /**
+     * Block IDs (e.g. "minecraft:black_concrete") that lasers pass through
+     * instead of stopping on. Use this for scenic decor blocks (backdrops,
+     * trusses made of regular blocks, etc.) so beams continue to a real wall
+     * behind them. Mod blocks from "theatrical" and "theatricalextralights"
+     * are always skipped — no need to list them.
+     */
+    private List<String> laserPassThroughBlocks = new java.util.ArrayList<>(Arrays.asList(
+            "minecraft:glass",
+            "minecraft:tinted_glass",
+            "minecraft:iron_bars",
+            "minecraft:barrier"
+    ));
+
+    private transient Set<String> laserPassThroughSet = null;
 
     /* ================= SINGLETON ================= */
 
@@ -42,6 +61,9 @@ public class TheatricalExtraLightsConfig {
 
                     if (loaded.renderLens != null)
                         defaults.renderLens = loaded.renderLens;
+
+                    if (loaded.laserPassThroughBlocks != null)
+                        defaults.laserPassThroughBlocks = loaded.laserPassThroughBlocks;
                 }
 
                 INSTANCE = defaults;
@@ -74,6 +96,10 @@ public class TheatricalExtraLightsConfig {
 
         if (renderLens == null)
             renderLens = true;
+
+        if (laserPassThroughBlocks == null)
+            laserPassThroughBlocks = new java.util.ArrayList<>();
+        laserPassThroughSet = new HashSet<>(laserPassThroughBlocks);
     }
     
     /* ================= GETTERS ================= */
@@ -88,6 +114,15 @@ public class TheatricalExtraLightsConfig {
 
     public static boolean shouldRenderLens() {
         return INSTANCE.renderLens;
+    }
+
+    public static boolean isLaserPassThrough(String blockId) {
+        if (INSTANCE.laserPassThroughSet == null) {
+            INSTANCE.laserPassThroughSet = INSTANCE.laserPassThroughBlocks == null
+                    ? new HashSet<>()
+                    : new HashSet<>(INSTANCE.laserPassThroughBlocks);
+        }
+        return INSTANCE.laserPassThroughSet.contains(blockId);
     }
 
     /* ================= SETTERS ================= */

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/laser/LaserPattern.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/laser/LaserPattern.java
@@ -89,34 +89,30 @@ public enum LaserPattern {
         float speed01 = clamp01(speedRaw / 255f);
         float rot01 = clamp01(rotationRaw / 255f);
 
-        // Animated motion with a 5% deadzone so DMX 0-12 are guaranteed static.
-        // Above the deadzone, speed scales linearly. For shape-rotating patterns
-        // (Circle, Square, Spiral, ...) Speed = rotation rate up to 360 deg/s.
-        // For Wave, Speed = phase-shift rate so the undulations slide along the
-        // line (1 cycle per second at max speed) — that's what users intuitively
-        // expect when they think "wave animation speed".
+        // Rotation comes ONLY from the Rotation DMX channel — Speed never
+        // rotates patterns. Speed DMX feeds shape animations that aren't
+        // rotation: wave phase sliding, scatter jitter rate, etc.
+        float staticRotDeg = rot01 * 360f;
+        // 5% deadzone so DMX 0-12 are static. Above that, scales linearly.
         final float speedDeadzone = 0.05f;
         float effectiveSpeed = (speed01 < speedDeadzone) ? 0f
                 : (speed01 - speedDeadzone) / (1f - speedDeadzone);
-        float speedDegPerSec = effectiveSpeed * 360f;
-        float animYawDeg = (float) (animTimeSec * speedDegPerSec);
-        float baseRotDeg = rot01 * 360f + animYawDeg;
-        float staticRotDeg = rot01 * 360f;
-        float animPhase = (float) (animTimeSec * effectiveSpeed);
+        // Wave phase advances at up to 2 cycles per second at max speed.
+        float animPhase = (float) (animTimeSec * effectiveSpeed * 2f);
 
         switch (this) {
             case BEAM_SIMPLE:    return beamSimple(size01, c1);
-            case LINE:           return line(size01, amp01, baseRotDeg, c1, c2, c3);
-            case CIRCLE:         return circle(size01, amp01, baseRotDeg, c1, c2, c3);
-            case SQUARE:         return square(size01, amp01, baseRotDeg, c1, c2, c3);
+            case LINE:           return line(size01, amp01, staticRotDeg, c1, c2, c3);
+            case CIRCLE:         return circle(size01, amp01, staticRotDeg, c1, c2, c3);
+            case SQUARE:         return square(size01, amp01, staticRotDeg, c1, c2, c3);
             case WAVE:           return wave(size01, amp01, staticRotDeg, animPhase, c1, c2, c3);
-            case TUNNEL:         return tunnel(size01, amp01, baseRotDeg, c1, c2, c3);
-            case STAR:           return star(size01, amp01, baseRotDeg, c1, c2, c3);
-            case CROSS:          return cross(size01, amp01, baseRotDeg, c1, c2, c3);
-            case TRIANGLE:       return triangle(size01, baseRotDeg, c1, c2, c3);
-            case SPIRAL:         return spiral(size01, amp01, baseRotDeg, c1, c2, c3);
-            case PARALLEL_LINES: return parallelLines(size01, amp01, baseRotDeg, c1, c2, c3);
-            case DOUBLE_CIRCLE:  return doubleCircle(size01, amp01, baseRotDeg, c1, c2, c3);
+            case TUNNEL:         return tunnel(size01, amp01, staticRotDeg, c1, c2, c3);
+            case STAR:           return star(size01, amp01, staticRotDeg, c1, c2, c3);
+            case CROSS:          return cross(size01, amp01, staticRotDeg, c1, c2, c3);
+            case TRIANGLE:       return triangle(size01, staticRotDeg, c1, c2, c3);
+            case SPIRAL:         return spiral(size01, amp01, staticRotDeg, c1, c2, c3);
+            case PARALLEL_LINES: return parallelLines(size01, amp01, staticRotDeg, c1, c2, c3);
+            case DOUBLE_CIRCLE:  return doubleCircle(size01, amp01, staticRotDeg, c1, c2, c3);
             case BURST:          return burst(size01, amp01, animTimeSec, c1, c2, c3);
             case SCATTER:        return scatter(size01, amp01, speed01, animTimeSec, c1, c2, c3);
         }
@@ -136,7 +132,7 @@ public enum LaserPattern {
      */
     private static List<LaserBeam> line(float size01, float amp01, float rotDeg,
                                         int c1, int c2, int c3) {
-        int count = 30;
+        int count = 80;
         float spanDeg = lerp(size01, 8f, 70f);
         float archDeg = lerp(amp01, 0f, 14f); // amp = arch height (parabolic)
         List<LaserBeam> out = new ArrayList<>(count);
@@ -159,7 +155,7 @@ public enum LaserPattern {
 
     private static List<LaserBeam> circle(float size01, float amp01, float rotDeg,
                                           int c1, int c2, int c3) {
-        int count = 24;
+        int count = 72;
         float radiusDeg = lerp(size01, 4f, 35f);
         float vertRadiusDeg = radiusDeg * lerp(amp01, 0.3f, 1.4f); // amp = ovale
         List<LaserBeam> out = new ArrayList<>(count);
@@ -176,7 +172,7 @@ public enum LaserPattern {
 
     private static List<LaserBeam> square(float size01, float amp01, float rotDeg,
                                           int c1, int c2, int c3) {
-        int perSide = 6;
+        int perSide = 18;
         float halfDeg = lerp(size01, 4f, 35f);
         float ratio = lerp(amp01, 1.0f, 1.8f); // amp = ratio largeur/hauteur
         float halfX = halfDeg * ratio;
@@ -214,7 +210,7 @@ public enum LaserPattern {
 
     private static List<LaserBeam> wave(float size01, float amp01, float rotDeg,
                                         float animPhase, int c1, int c2, int c3) {
-        int count = 60;
+        int count = 150;
         float spanDeg = lerp(size01, 12f, 70f);   // total horizontal span
         float ampDeg = lerp(amp01, 2f, 25f);       // wave height
         int waves = 3;
@@ -239,7 +235,7 @@ public enum LaserPattern {
     private static List<LaserBeam> tunnel(float size01, float amp01, float rotDeg,
                                           int c1, int c2, int c3) {
         int rings = 4;
-        int perRing = 12;
+        int perRing = 28;
         float baseRadiusDeg = lerp(size01, 3f, 20f);
         float ringSpacingDeg = lerp(amp01, 1f, 8f); // amp = depth
         List<LaserBeam> out = new ArrayList<>(rings * perRing);
@@ -265,7 +261,7 @@ public enum LaserPattern {
                                         int c1, int c2, int c3) {
         int points = 5;
         int verticesTotal = points * 2;
-        int perEdge = 4;
+        int perEdge = 12;
         float outerRadius = lerp(size01, 6f, 35f);
         float innerRadius = outerRadius * lerp(amp01, 0.55f, 0.20f); // smaller inner = sharper points
         float[][] verts = new float[verticesTotal][2];
@@ -295,7 +291,7 @@ public enum LaserPattern {
 
     private static List<LaserBeam> cross(float size01, float amp01, float rotDeg,
                                          int c1, int c2, int c3) {
-        int perBranch = 6;
+        int perBranch = 18;
         float length = lerp(size01, 6f, 35f);
         float thickness = lerp(amp01, 0.5f, 4f);
         // 4 branches: +X, -X, +Y, -Y, each is a small rectangle drawn as a line of beams
@@ -323,7 +319,7 @@ public enum LaserPattern {
 
     private static List<LaserBeam> triangle(float size01, float rotDeg,
                                             int c1, int c2, int c3) {
-        int perEdge = 8;
+        int perEdge = 24;
         float radius = lerp(size01, 6f, 35f);
         float[][] verts = new float[3][2];
         for (int v = 0; v < 3; v++) {
@@ -351,7 +347,7 @@ public enum LaserPattern {
 
     private static List<LaserBeam> spiral(float size01, float amp01, float rotDeg,
                                           int c1, int c2, int c3) {
-        int count = 28;
+        int count = 90;
         float maxRadius = lerp(size01, 8f, 35f);
         float pitch01 = lerp(amp01, 0.4f, 2.0f); // tighter or looser turns
         float turns = 2.5f * pitch01;
@@ -371,7 +367,7 @@ public enum LaserPattern {
     private static List<LaserBeam> parallelLines(float size01, float amp01, float rotDeg,
                                                  int c1, int c2, int c3) {
         int lineCount = 4 + (int) (amp01 * 8); // amp = number of lines (4..12)
-        int perLine = 8;
+        int perLine = 24;
         float spacingDeg = lerp(size01, 2f, 8f);
         float lineLengthDeg = 30f;
         List<LaserBeam> out = new ArrayList<>(lineCount * perLine);
@@ -399,8 +395,8 @@ public enum LaserPattern {
 
     private static List<LaserBeam> doubleCircle(float size01, float amp01, float rotDeg,
                                                 int c1, int c2, int c3) {
-        int countOuter = 16;
-        int countInner = 16;
+        int countOuter = 48;
+        int countInner = 48;
         float outer = lerp(size01, 6f, 35f);
         float inner = outer * lerp(amp01, 0.85f, 0.40f); // amp = écart entre cercles
         List<LaserBeam> out = new ArrayList<>(countOuter + countInner);


### PR DESCRIPTION
## Laser Fixture — DMX Channel Layout

The laser uses a single DMX personality with **19 channels**.

| Channel | Name        | Range  | Description                                                                                |
|---------|-------------|--------|--------------------------------------------------------------------------------------------|
| 1       | Intensity   | 0–255  | Overall brightness. At 0 the laser is off and renders nothing.                             |
| 2       | Red 1       | 0–255  | Red component of the primary color.                                                        |
| 3       | Green 1     | 0–255  | Green component of the primary color.                                                      |
| 4       | Blue 1      | 0–255  | Blue component of the primary color.                                                       |
| 5       | Red 2       | 0–255  | Red component of the secondary color (middle stop of the gradient).                        |
| 6       | Green 2     | 0–255  | Green component of the secondary color.                                                    |
| 7       | Blue 2      | 0–255  | Blue component of the secondary color.                                                     |
| 8       | Red 3       | 0–255  | Red component of the tertiary color (end of the gradient).                                 |
| 9       | Green 3     | 0–255  | Green component of the tertiary color.                                                     |
| 10      | Blue 3      | 0–255  | Blue component of the tertiary color.                                                      |
| 11      | Pattern     | 0–255  | Selects the pattern shape. 14 patterns mapped to 18-wide buckets (see table below).        |
| 12      | Size        | 0–255  | Angular size / spread of the pattern.                                                      |
| 13      | Amplitude   | 0–255  | Pattern-specific amplitude (e.g. wave height, ring spacing, star sharpness, line count).   |
| 14      | Speed       | 0–255  | Pattern animation speed (wave phase shift, scatter jitter rate, etc.). 5% deadzone at the bottom guarantees DMX 0–12 is fully static. Does NOT rotate the shape. |
| 15      | Rotation    | 0–255  | Static rotation of the pattern, mapped to 0–360°.                                          |
| 16      | Pan         | 0–255  | Pan, mapped to ±80° (128 = center).                                                        |
| 17      | Tilt        | 0–255  | Tilt, mapped to ±45° (128 = center).                                                       |
| 18      | Focus       | 0–255  | Beam shaft thickness.                                                                      |
| 19      | Persistence | 0–255  | Reserved for future use (the scanning trail effect is currently disabled).                 |

### Pattern selector (Channel 11)

The Pattern channel is divided into 14 equal buckets of ~18 DMX values each:

| DMX Range | Pattern         |
|-----------|-----------------|
| 0–17      | BEAM_SIMPLE     |
| 18–35     | LINE            |
| 36–53     | CIRCLE          |
| 54–71     | SQUARE          |
| 72–89     | WAVE            |
| 90–107    | TUNNEL          |
| 108–125   | STAR            |
| 126–143   | CROSS           |
| 144–161   | TRIANGLE        |
| 162–179   | SPIRAL          |
| 180–197   | PARALLEL_LINES  |
| 198–215   | DOUBLE_CIRCLE   |
| 216–233   | BURST           |
| 234–255   | SCATTER         |

### Color gradient behavior

The three color stops (C1 → C2 → C3) are sampled across the beams of the pattern in order, producing a tri-color gradient along the shape.

If C2 is left at full black (0,0,0), it automatically falls back to C1. If C3 is left at full black, it falls back to C2. This makes monochromatic patterns easy: set only C1 and leave C2/C3 untouched.

### Beam length & wall behavior

Beams are clipped at the first solid wall they hit (raycast), capped by `laserBeamLength` from `config/theatricalextralights.json` (default 400 blocks). The last 20% of the visible beam fades to 0% alpha for a soft falloff.

Decorative blocks the laser should pass through (glass, iron bars, barriers, scenic backdrops) can be listed in `laserPassThroughBlocks` in the same config file. All Theatrical and TheatricalExtraLights mod blocks are always passed through.
