### PR TITLE
fix: stabilize pyro launches and purge sky rocket orphans

### DIFF
--- a/common/src/main/java/com/github/dumann089/theatricalextralights/TheatricalExtraLights.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/TheatricalExtraLights.java
@@ -5,6 +5,7 @@ import com.github.dumann089.theatricalextralights.blocks.Blocks;
 import com.github.dumann089.theatricalextralights.config.TheatricalExtraLightsConfig;
 import com.github.dumann089.theatricalextralights.entities.ModEntities;
 import com.github.dumann089.theatricalextralights.fixtures.Fixtures;
+import com.github.dumann089.theatricalextralights.firework.FireworkRocketTracker;
 import com.github.dumann089.theatricalextralights.items.Items;
 import com.github.dumann089.theatricalextralights.net.ExtraLightsNet;
 import com.github.dumann089.theatricalextralights.net.ModNetworkHandler;
@@ -52,6 +53,7 @@ public class TheatricalExtraLights {
         ModNetworkHandler.register();
         ExtraLightsNet.init();
         TheatricalExtraLightsConfig.load();
+        FireworkRocketTracker.registerEvents();
     }
 }
 

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/blockentities/FireworkLauncherBlockEntity.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/blockentities/FireworkLauncherBlockEntity.java
@@ -42,6 +42,8 @@ public class FireworkLauncherBlockEntity extends ExtraLightsLightBlockEntity {
     private static final float LAUNCH_SPEED = 2.0f;
     private static final float MIN_LAUNCH_POWER = 0.7f;
     private static final float MAX_LAUNCH_POWER = 2.6f;
+    private static final int MAX_LAUNCHES_PER_TICK = 4;
+    private static final float MAX_ACCUMULATOR = 4.0f;
     private static final double TUBE_LENGTH = 10.0 / 16.0;
     private static final double TUBE_BASE_HEIGHT = 4.0 / 16.0;
 
@@ -84,8 +86,12 @@ public class FireworkLauncherBlockEntity extends ExtraLightsLightBlockEntity {
             return;
         }
 
+        int launchesThisTick = 0;
+
         if (pendingOneShot) {
-            launch(serverLevel);
+            if (launch(serverLevel)) {
+                launchesThisTick++;
+            }
             pendingOneShot = false;
         }
 
@@ -95,15 +101,19 @@ public class FireworkLauncherBlockEntity extends ExtraLightsLightBlockEntity {
         }
 
         fireAccumulator += getShotsPerSecond() / 20.0f;
-        while (fireAccumulator >= 1.0f) {
+        fireAccumulator = Math.min(fireAccumulator, MAX_ACCUMULATOR);
+        while (fireAccumulator >= 1.0f && launchesThisTick < MAX_LAUNCHES_PER_TICK) {
+            if (!launch(serverLevel)) {
+                break;
+            }
             fireAccumulator -= 1.0f;
-            launch(serverLevel);
+            launchesThisTick++;
         }
     }
 
-    private void launch(ServerLevel serverLevel) {
+    private boolean launch(ServerLevel serverLevel) {
         if (!FireworkRocketTracker.tryRegisterLaunch(serverLevel)) {
-            return;
+            return false;
         }
         Vec3 spawn = getLaunchPosition();
         Vec3 velocity = getLaunchVelocity();
@@ -112,9 +122,10 @@ public class FireworkLauncherBlockEntity extends ExtraLightsLightBlockEntity {
         rocket.setDeltaMovement(velocity);
         if (!serverLevel.addFreshEntity(rocket)) {
             FireworkRocketTracker.cancelLaunch(serverLevel);
-            return;
+            return false;
         }
         serverLevel.playSound(null, spawn.x, spawn.y, spawn.z, SoundEvents.FIREWORK_ROCKET_LAUNCH, SoundSource.BLOCKS, 0.9f, 0.9f + serverLevel.random.nextFloat() * 0.2f);
+        return true;
     }
 
     protected FireworkRocketEntity createRocket(ServerLevel serverLevel) {

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/blockentities/PyroFanBlockEntity.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/blockentities/PyroFanBlockEntity.java
@@ -39,12 +39,15 @@ public class PyroFanBlockEntity extends ExtraLightsLightBlockEntity implements H
     private static final float BASE_LAUNCH_SPEED = 1.68f;
     private static final float MIN_SHOTS_PER_SECOND = 0.5f;
     private static final float MAX_SHOTS_PER_SECOND = 6.0f;
+    private static final int MAX_LAUNCHES_PER_TICK = 4;
+    private static final float MAX_ACCUMULATOR = 4.0f;
     private static final double TUBE_BASE_HEIGHT = 4.0 / 16.0;
 
     private final int[] tubeIntensity = new int[TUBE_COUNT];
     private final int[] prevTubeIntensity = new int[TUBE_COUNT];
     private final float[] fireAccumulator = new float[TUBE_COUNT];
     private final boolean[] pendingOneShot = new boolean[TUBE_COUNT];
+    private int launchRoundRobin;
     private int activePersonalityIndex = PyroFanFixture.PERSONALITY_3CH;
 
     public PyroFanBlockEntity(BlockPos pos, BlockState state) {
@@ -97,17 +100,25 @@ public class PyroFanBlockEntity extends ExtraLightsLightBlockEntity implements H
             return;
         }
 
-        for (int tube = 0; tube < TUBE_COUNT; tube++) {
+        int launchesThisTick = 0;
+
+        for (int offset = 0; offset < TUBE_COUNT && launchesThisTick < MAX_LAUNCHES_PER_TICK; offset++) {
+            int tube = (launchRoundRobin + offset) % TUBE_COUNT;
+            if (!pendingOneShot[tube] || tubeIntensity[tube] <= 0) {
+                continue;
+            }
+            if (launchTube(serverLevel, tube)) {
+                launchesThisTick++;
+                pendingOneShot[tube] = false;
+            }
+        }
+        launchRoundRobin = (launchRoundRobin + 1) % TUBE_COUNT;
+
+        for (int tube = 0; tube < TUBE_COUNT && launchesThisTick < MAX_LAUNCHES_PER_TICK; tube++) {
             int intensity = tubeIntensity[tube];
             if (intensity <= 0) {
                 fireAccumulator[tube] = 0.0f;
-                pendingOneShot[tube] = false;
                 continue;
-            }
-
-            if (pendingOneShot[tube]) {
-                launchTube(serverLevel, tube);
-                pendingOneShot[tube] = false;
             }
 
             if (intensity < 2) {
@@ -116,16 +127,20 @@ public class PyroFanBlockEntity extends ExtraLightsLightBlockEntity implements H
             }
 
             fireAccumulator[tube] += shotsPerSecond(intensity) / 20.0f;
-            while (fireAccumulator[tube] >= 1.0f) {
+            fireAccumulator[tube] = Math.min(fireAccumulator[tube], MAX_ACCUMULATOR);
+            while (fireAccumulator[tube] >= 1.0f && launchesThisTick < MAX_LAUNCHES_PER_TICK) {
+                if (!launchTube(serverLevel, tube)) {
+                    break;
+                }
                 fireAccumulator[tube] -= 1.0f;
-                launchTube(serverLevel, tube);
+                launchesThisTick++;
             }
         }
     }
 
-    private void launchTube(ServerLevel serverLevel, int tubeIndex) {
+    private boolean launchTube(ServerLevel serverLevel, int tubeIndex) {
         if (!FireworkRocketTracker.tryRegisterLaunch(serverLevel)) {
-            return;
+            return false;
         }
 
         Vec3 spawn = getTubeLaunchPosition(tubeIndex);
@@ -135,7 +150,7 @@ public class PyroFanBlockEntity extends ExtraLightsLightBlockEntity implements H
         rocket.setDeltaMovement(velocity);
         if (!serverLevel.addFreshEntity(rocket)) {
             FireworkRocketTracker.cancelLaunch(serverLevel);
-            return;
+            return false;
         }
         serverLevel.playSound(
                 null,
@@ -147,6 +162,7 @@ public class PyroFanBlockEntity extends ExtraLightsLightBlockEntity implements H
                 0.75f,
                 0.85f + serverLevel.random.nextFloat() * 0.25f
         );
+        return true;
     }
 
     private void applyTubeIntensity(int tubeIndex, int newIntensity) {

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/entities/FireworkRocketEntity.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/entities/FireworkRocketEntity.java
@@ -16,6 +16,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -33,6 +36,11 @@ import java.util.UUID;
 public class FireworkRocketEntity extends Entity implements EntitySpawnExtension, DynamicLightProvider {
     private static final int MAX_TOTAL_TICKS = 400;
 
+    private static final EntityDataAccessor<Boolean> DATA_EXPLODED =
+            SynchedEntityData.defineId(FireworkRocketEntity.class, EntityDataSerializers.BOOLEAN);
+    private static final EntityDataAccessor<Boolean> DATA_FADING =
+            SynchedEntityData.defineId(FireworkRocketEntity.class, EntityDataSerializers.BOOLEAN);
+
     private FireworkPreset preset = FireworkPreset.RED_COMET;
     private BlockPos launcherPos = BlockPos.ZERO;
     private int life;
@@ -49,7 +57,7 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
 
     public FireworkRocketEntity(EntityType<? extends FireworkRocketEntity> entityType, Level level) {
         super(entityType, level);
-        noPhysics = false;
+        noPhysics = true;
     }
 
     public FireworkRocketEntity(Level level, FireworkPreset preset, BlockPos launcherPos) {
@@ -98,6 +106,29 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
         return life;
     }
 
+    /** Server-side max lifetime for this rocket's preset (see {@link BurstPattern#getServerHoldTicks()}). */
+    public int getServerHoldTicks() {
+        return preset.getPattern().getServerHoldTicks();
+    }
+
+    /**
+     * True when this rocket should be removed to avoid stacking in unloaded sky chunks.
+     */
+    public boolean shouldForceCleanup(ServerLevel level) {
+        if (tickCount > getServerHoldTicks() || tickCount > MAX_TOTAL_TICKS) {
+            return true;
+        }
+        double dx = getX() - (launcherPos.getX() + 0.5);
+        double dz = getZ() - (launcherPos.getZ() + 0.5);
+        if (dx * dx + dz * dz > 72.0 * 72.0) {
+            return true;
+        }
+        if (getY() > launcherPos.getY() + 64.0 || getY() > 260.0) {
+            return true;
+        }
+        return tickCount > 24 && !FireworkRocketTracker.hasNearbyPlayer(level, this);
+    }
+
     public BlockPos getLauncherPos() {
         return launcherPos;
     }
@@ -134,6 +165,8 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
 
     @Override
     protected void defineSynchedData() {
+        entityData.define(DATA_EXPLODED, false);
+        entityData.define(DATA_FADING, false);
     }
 
     @Override
@@ -179,22 +212,31 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
     public void tick() {
         super.tick();
 
-        if (tickCount > MAX_TOTAL_TICKS) {
-            releaseLight();
-            discard();
-            return;
-        }
-
         BurstPattern pattern = preset.getPattern();
-        if (!level().isClientSide && tickCount > pattern.getServerHoldTicks()) {
-            releaseLight();
-            discard();
-            return;
-        }
-
         boolean clientSide = level().isClientSide;
 
+        if (tickCount > MAX_TOTAL_TICKS) {
+            releaseLight();
+            if (!clientSide) {
+                discard();
+            }
+            return;
+        }
+
+        if (!clientSide && tickCount > pattern.getServerHoldTicks()) {
+            releaseLight();
+            discard();
+            return;
+        }
+
+        if (!clientSide && level() instanceof ServerLevel serverLevel && shouldForceCleanup(serverLevel)) {
+            releaseLight();
+            discard();
+            return;
+        }
+
         if (clientSide) {
+            syncVisualPhaseFromNetwork(pattern);
             tickClientLight();
             tickSparks();
 
@@ -220,9 +262,12 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
 
         if (exploded) {
             burstTickIndex++;
-            if (clientSide && burstTickIndex >= pattern.getBurstDuration() && sparks.isEmpty()) {
-                releaseLight();
-                discard();
+            if (clientSide && burstTickIndex >= pattern.getBurstDuration()) {
+                sparks.removeIf(Spark::isDead);
+                if (sparks.isEmpty() || burstTickIndex >= pattern.getBurstDuration() + 80) {
+                    sparks.clear();
+                    releaseLight();
+                }
             }
             return;
         }
@@ -232,9 +277,12 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
             double fadeDrag = 0.94;
             setDeltaMovement(fadeMotion.x * fadeDrag, fadeMotion.y * fadeDrag - 0.025, fadeMotion.z * fadeDrag);
             move(MoverType.SELF, getDeltaMovement());
-            if (clientSide && --fadeTicks <= 0 && sparks.isEmpty()) {
-                releaseLight();
-                discard();
+            if (clientSide && --fadeTicks <= 0) {
+                sparks.removeIf(Spark::isDead);
+                if (sparks.isEmpty() || fadeTicks <= -20) {
+                    sparks.clear();
+                    releaseLight();
+                }
             }
             return;
         }
@@ -259,9 +307,84 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
         move(MoverType.SELF, getDeltaMovement());
 
         boolean reachedApex = !pattern.continuesAfterApex() && getDeltaMovement().y <= 0.0 && life > 10;
-        if (horizontalCollision || verticalCollision || onGround() || life >= pattern.getFlightLifetime() || reachedApex) {
-            triggerEnd();
+        boolean endFlight = life >= pattern.getFlightLifetime() || reachedApex;
+        if (endFlight) {
+            if (clientSide) {
+                beginClientEndPhase(pattern);
+            } else {
+                triggerEnd();
+            }
         }
+    }
+
+    /** Client predicts burst/fade at apex so visuals do not wait on network sync. */
+    private void beginClientEndPhase(BurstPattern pattern) {
+        if (exploded || fading) {
+            return;
+        }
+        if (pattern.isBurst()) {
+            exploded = true;
+            fading = false;
+            burstTickIndex = 0;
+            burstStarted = false;
+            setDeltaMovement(Vec3.ZERO);
+        } else if (pattern.getCometFadeTicks() > 0) {
+            fading = true;
+            exploded = false;
+            fadeTicks = pattern.getCometFadeTicks();
+        }
+    }
+
+    @Override
+    public void lerpTo(double x, double y, double z, float yRot, float xRot, int steps, boolean teleport) {
+        if (level().isClientSide) {
+            if (teleport) {
+                setPos(x, y, z);
+            }
+            return;
+        }
+        super.lerpTo(x, y, z, yRot, xRot, steps, teleport);
+    }
+
+    private void syncVisualPhaseFromNetwork(BurstPattern pattern) {
+        boolean syncedExploded = entityData.get(DATA_EXPLODED);
+        boolean syncedFading = entityData.get(DATA_FADING);
+
+        if (syncedExploded) {
+            if (!exploded) {
+                burstTickIndex = 0;
+                burstStarted = false;
+                setDeltaMovement(Vec3.ZERO);
+            }
+            exploded = true;
+            fading = false;
+            return;
+        }
+
+        if (syncedFading) {
+            if (!fading) {
+                fadeTicks = pattern.getCometFadeTicks();
+            }
+            fading = true;
+            exploded = false;
+        }
+    }
+
+    private void setSyncedExploded() {
+        exploded = true;
+        fading = false;
+        burstTickIndex = 0;
+        setDeltaMovement(Vec3.ZERO);
+        entityData.set(DATA_EXPLODED, true);
+        entityData.set(DATA_FADING, false);
+    }
+
+    private void setSyncedFading(BurstPattern pattern) {
+        fading = true;
+        exploded = false;
+        fadeTicks = pattern.getCometFadeTicks();
+        entityData.set(DATA_FADING, true);
+        entityData.set(DATA_EXPLODED, false);
     }
 
     private void tickSparks() {
@@ -276,32 +399,22 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
             return;
         }
         BurstPattern pattern = preset.getPattern();
-        if (level() instanceof ServerLevel serverLevel) {
-            if (pattern.isBurst()) {
-                if (!pattern.isDaytimePowder()) {
-                    serverLevel.playSound(null, getX(), getY(), getZ(), SoundEvents.FIREWORK_ROCKET_BLAST, SoundSource.BLOCKS, 1.0f, 0.95f + random.nextFloat() * 0.1f);
-                    if (pattern.hasCrackleSound()) {
-                        serverLevel.playSound(null, getX(), getY(), getZ(), SoundEvents.FIREWORK_ROCKET_TWINKLE, SoundSource.BLOCKS, 0.9f, 0.9f + random.nextFloat() * 0.2f);
-                    }
+        if (!(level() instanceof ServerLevel serverLevel)) {
+            return;
+        }
+        if (pattern.isBurst()) {
+            if (!pattern.isDaytimePowder()) {
+                serverLevel.playSound(null, getX(), getY(), getZ(), SoundEvents.FIREWORK_ROCKET_BLAST, SoundSource.BLOCKS, 1.0f, 0.95f + random.nextFloat() * 0.1f);
+                if (pattern.hasCrackleSound()) {
+                    serverLevel.playSound(null, getX(), getY(), getZ(), SoundEvents.FIREWORK_ROCKET_TWINKLE, SoundSource.BLOCKS, 0.9f, 0.9f + random.nextFloat() * 0.2f);
                 }
-                exploded = true;
-                burstTickIndex = 0;
-                setDeltaMovement(Vec3.ZERO);
-            } else if (pattern.getCometFadeTicks() > 0) {
-                serverLevel.playSound(null, getX(), getY(), getZ(), SoundEvents.FIREWORK_ROCKET_BLAST_FAR, SoundSource.BLOCKS, 0.4f, 1.1f + random.nextFloat() * 0.15f);
-                fading = true;
-                fadeTicks = pattern.getCometFadeTicks();
-            } else {
-                discard();
             }
+            setSyncedExploded();
+        } else if (pattern.getCometFadeTicks() > 0) {
+            serverLevel.playSound(null, getX(), getY(), getZ(), SoundEvents.FIREWORK_ROCKET_BLAST_FAR, SoundSource.BLOCKS, 0.4f, 1.1f + random.nextFloat() * 0.15f);
+            setSyncedFading(pattern);
         } else {
-            if (pattern.isBurst()) {
-                exploded = true;
-                burstTickIndex = 0;
-            } else if (pattern.getCometFadeTicks() > 0) {
-                fading = true;
-                fadeTicks = pattern.getCometFadeTicks();
-            }
+            discard();
         }
     }
 
@@ -370,13 +483,13 @@ public class FireworkRocketEntity extends Entity implements EntitySpawnExtension
         } else {
             customColors = null;
         }
+        entityData.set(DATA_EXPLODED, exploded);
+        entityData.set(DATA_FADING, fading);
     }
 
     @Override
     public void remove(RemovalReason reason) {
-        if (!level().isClientSide) {
-            FireworkRocketTracker.onRemoved(level());
-        }
+        releaseLight();
         FireworkLightCompat.remove(this);
         shimmerLightRegistered = false;
         super.remove(reason);

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/firework/BurstPattern.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/firework/BurstPattern.java
@@ -111,17 +111,23 @@ public abstract class BurstPattern {
     }
 
     /**
-     * Server-side entity lifetime — client keeps sparks locally until they fade.
-     * Must stay below client visual duration but release tracker slots promptly.
+     * Server-side entity lifetime. Kept short for comets so concurrent slots recycle
+     * during pyro fan shows (full arc is simulated client-side).
      */
     public int getServerHoldTicks() {
         if (isDaytimePowder()) {
-            return 400;
+            if (isBurst()) {
+                return getBurstDuration() + 55;
+            }
+            return getFlightLifetime() + getCometFadeTicks() + 40;
         }
         if (isBurst()) {
-            return getBurstDuration() + 160;
+            return getBurstDuration() + 110;
         }
-        return getFlightLifetime() + getCometFadeTicks() + 160;
+        if (continuesAfterApex()) {
+            return getFlightLifetime() + getCometFadeTicks() + 24;
+        }
+        return 64;
     }
 
     /** Daytime powder — visible in daylight, minimal dynamic light. */

--- a/common/src/main/java/com/github/dumann089/theatricalextralights/firework/FireworkRocketTracker.java
+++ b/common/src/main/java/com/github/dumann089/theatricalextralights/firework/FireworkRocketTracker.java
@@ -2,15 +2,36 @@ package com.github.dumann089.theatricalextralights.firework;
 
 import com.github.dumann089.theatricalextralights.config.TheatricalExtraLightsConfig;
 import com.github.dumann089.theatricalextralights.entities.FireworkRocketEntity;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import dev.architectury.event.events.common.TickEvent;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Limits concurrent firework rockets and reclaims orphans that stack in sky chunks.
+ */
 public final class FireworkRocketTracker {
-    private static final Object2IntOpenHashMap<Level> ACTIVE = new Object2IntOpenHashMap<>();
+    private static final AABB WORLD_BOUNDS = new AABB(-3.0E7, -64, -3.0E7, 3.0E7, 320, 3.0E7);
+    private static final int ABSOLUTE_MAX_TICKS = 420;
+    private static final double PLAYER_KEEP_RANGE = 160.0;
 
     private FireworkRocketTracker() {
+    }
+
+    public static void registerEvents() {
+        TickEvent.SERVER_LEVEL_POST.register(FireworkRocketTracker::onServerLevelTick);
+    }
+
+    private static void onServerLevelTick(ServerLevel level) {
+        if (level.getGameTime() % 20L != 0L) {
+            return;
+        }
+        cleanupOrphans(level);
     }
 
     public static boolean tryRegisterLaunch(Level level) {
@@ -18,38 +39,76 @@ public final class FireworkRocketTracker {
         if (max <= 0) {
             return true;
         }
-        synchronized (ACTIVE) {
-            int count = ACTIVE.getInt(level);
-            if (count >= max) {
-                resyncCount(level);
-                count = ACTIVE.getInt(level);
-                if (count >= max) {
-                    return false;
-                }
-            }
-            ACTIVE.put(level, count + 1);
+        if (!(level instanceof ServerLevel serverLevel)) {
             return true;
         }
+
+        int count = countActive(serverLevel);
+        if (count >= max) {
+            purgeExpired(serverLevel);
+        } else if (count > max / 2) {
+            cleanupOrphans(serverLevel);
+        }
+
+        return countActive(serverLevel) < max;
     }
 
     public static void cancelLaunch(Level level) {
-        onRemoved(level);
     }
 
     public static void onRemoved(Level level) {
-        synchronized (ACTIVE) {
-            ACTIVE.put(level, Math.max(0, ACTIVE.getInt(level) - 1));
+    }
+
+    public static int countActive(ServerLevel level) {
+        return level.getEntitiesOfClass(FireworkRocketEntity.class, WORLD_BOUNDS).size();
+    }
+
+    /** Reclaim rockets that flew too far/high or linger without nearby players. */
+    public static void cleanupOrphans(ServerLevel level) {
+        for (FireworkRocketEntity rocket : List.copyOf(level.getEntitiesOfClass(FireworkRocketEntity.class, WORLD_BOUNDS))) {
+            if (rocket.shouldForceCleanup(level)) {
+                rocket.discard();
+            }
         }
     }
 
-    private static void resyncCount(Level level) {
-        if (!(level instanceof ServerLevel serverLevel)) {
+    public static void purgeFinished(ServerLevel level) {
+        for (FireworkRocketEntity rocket : level.getEntitiesOfClass(FireworkRocketEntity.class, WORLD_BOUNDS)) {
+            int hold = rocket.getPreset().getPattern().getServerHoldTicks();
+            if (rocket.tickCount > hold || rocket.tickCount > ABSOLUTE_MAX_TICKS || rocket.shouldForceCleanup(level)) {
+                rocket.discard();
+            }
+        }
+    }
+
+    public static void purgeExpired(ServerLevel level) {
+        purgeFinished(level);
+
+        int max = TheatricalExtraLightsConfig.getMaxConcurrentRockets();
+        if (max <= 0) {
             return;
         }
-        int actual = serverLevel.getEntitiesOfClass(
-                FireworkRocketEntity.class,
-                new AABB(-3.0E7, -64, -3.0E7, 3.0E7, 320, 3.0E7)
-        ).size();
-        ACTIVE.put(level, actual);
+
+        List<FireworkRocketEntity> rockets = new ArrayList<>(
+                level.getEntitiesOfClass(FireworkRocketEntity.class, WORLD_BOUNDS)
+        );
+        while (rockets.size() > max) {
+            rockets.sort(Comparator.comparingInt(r -> r.tickCount));
+            if (rockets.isEmpty()) {
+                break;
+            }
+            rockets.remove(0).discard();
+            rockets = new ArrayList<>(level.getEntitiesOfClass(FireworkRocketEntity.class, WORLD_BOUNDS));
+        }
+    }
+
+    public static boolean hasNearbyPlayer(ServerLevel level, FireworkRocketEntity rocket) {
+        AABB box = rocket.getBoundingBox().inflate(PLAYER_KEEP_RANGE);
+        for (ServerPlayer player : level.getEntitiesOfClass(ServerPlayer.class, box)) {
+            if (!player.isSpectator() && !player.isDeadOrDying()) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

- Fixes **pyro launches getting blocked** when the 768-rocket limit becomes saturated by orphaned entities (sky chunks that never despawn).
- Stabilizes **client-side rendering** (stuttering, teleporting) and smooths **high-rate DMX firing bursts** on the Pyro Fan and Firework Launcher.

## Fixed Issues

| Symptom | Cause | Fix |
|----------|--------|--------|
| ~1 launch out of 20, then nothing | Manual counter + rockets never released | `FireworkRocketTracker` now counts real entities and performs periodic cleanup |
| "Broken" world / noclip after a show | Rockets stuck in sky chunks and never despawning | `shouldForceCleanup()` + janitor task every 20 ticks |
| Client stutter / teleporting rockets | Server position sync fighting client physics | Dedicated client-side physics, client ignores `lerpTo`, burst/fade synchronized through `SynchedEntityData` |
| Sudden firing bursts | Unbounded DMX accumulator | Max **4 launches per tick**, capped accumulator, round-robin scheduling for Pyro Fan |

## Technical Details

- **`FireworkRocketTracker`**
  - Added `cleanupOrphans()`
  - Added `purgeExpired()`
  - Registered cleanup hook on `TickEvent.SERVER_LEVEL_POST`

- **`FireworkRocketEntity`**
  - Uses `noPhysics` on the client during the final phase
  - Prevents premature client-side `discard()`
  - Added `beginClientEndPhase()`

- **`BurstPattern`**
  - Increased server-side comet lifetime to **64 ticks** via `getServerHoldTicks()`

- **`PyroFanBlockEntity` / `FireworkLauncherBlockEntity`**
  - Launch throttling added
  - DMX accumulator is only decremented when a launch succeeds
  - One-shot triggers are preserved when a launch fails

## Test Plan

- [x] Run a heavy pyro show (Pyro Fan 10ch + multiple launchers) for several minutes — no launch lockups near the 768-entity limit.
- [x] Reload a world that previously hosted pyro shows and wait 10–20 seconds with no active pyro — orphaned rockets should be removed by the janitor task.
- [x] Verify comet and daytime powder trajectories — no visible client-side stuttering.
- [x] Test high-frequency DMX bursts — maximum ~4 launches per tick, no instant burst when restarting a show.
- [x] Validate JAR build: `TheatricalExtraLights-forge-1.4.6-beta-mc1.20.1.jar`